### PR TITLE
extending helper_replace_values_with_map method

### DIFF
--- a/helpers/transformations.r
+++ b/helpers/transformations.r
@@ -3,8 +3,18 @@ helper_tr_add_suffix_to_list <- function(l, suffix) {
     return(sprintf(paste0("%s", suffix), l))
 }
 
+helper_replace_values_with_map <- function(data, values, map,
+                                           drop_rest = FALSE, na_fill = "") {
+    if (!drop_rest) {
+        unique_values <- unique(data)
+        for (uv in unique_values) {
+            if (!(uv %in% values)) {
+                values <- append(values, uv)
+                map <- append(map, uv)
+            }
+        }
+    }
 
-helper_replace_values_with_map <- function(data, values, map, na_fill = "") {
     dict <- data.frame(
         val = values,
         map = map


### PR DESCRIPTION
Extending the functionality of a helper function: now it does not drop non-mapped values if drop_rest is FALSE. drop_rest is FALSE by default.

```r

data = c(1,2,3,4,5,6,7,8,9,10)
values = c(1,2,3)
map = c("one", "two", "three")

print(helper_replace_values_with_map(data, values, map))

# outputs 
#  [1] "one"   "two"   "three"  "4"     "5"     "6"     "7"     "8"     "9"    
#  [10] "10"   

```